### PR TITLE
Remove deprecated Digest::Digest

### DIFF
--- a/lib/yboss/oauth.rb
+++ b/lib/yboss/oauth.rb
@@ -44,7 +44,7 @@ module YBoss
       key = percent_encode( @consumer_secret ) + '&' + percent_encode( @token_secret )
 
       # ref: http://blog.nathanielbibler.com/post/63031273/openssl-hmac-vs-ruby-hmac-benchmarks
-      digest = OpenSSL::Digest::Digest.new( 'sha1' )
+      digest = OpenSSL::Digest.new( 'sha1' )
       hmac = OpenSSL::HMAC.digest( digest, key, @base_str )
 
       # ref http://groups.google.com/group/oauth-ruby/browse_thread/thread/9110ed8c8f3cae81


### PR DESCRIPTION
Ruby 2.1.x now complains about the deprecated OpenSSL::Digest::Digest, which was a pre ruby 1.8.7 convention.

https://github.com/ruby/ruby/pull/446